### PR TITLE
Enhance gallery UX with side navigation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,10 +7,14 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <h1>🎨 Jimi421 Art Gallery</h1>
+  <button id="navToggle" class="nav-toggle">☰</button>
 
-  <!-- Group filters -->
-  <div id="groupButtons"></div>
+  <div id="sideNav" class="sidenav">
+    <h2>Groups</h2>
+    <div id="groupButtons"></div>
+  </div>
+
+  <h1>🎨 Jimi421 Art Gallery</h1>
 
   <!-- Main gallery grid -->
   <div id="gallery"></div>
@@ -40,6 +44,11 @@
   <div id="toast"></div>
 
   <!-- Scripts -->
-  <script src="script.js"></script>
+  <script src="/scripts/script.js"></script>
+  <script>
+    document.getElementById('navToggle').onclick = () => {
+      document.getElementById('sideNav').classList.toggle('open');
+    };
+  </script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -5,6 +5,39 @@ body {
   color: #222;
 }
 
+/* Slide-out navigation */
+#sideNav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 240px;
+  background: #fff;
+  box-shadow: 2px 0 5px rgba(0,0,0,0.2);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 1000;
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+#sideNav.open {
+  transform: translateX(0);
+}
+
+#navToggle {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  z-index: 1100;
+  border: none;
+  background: #3498db;
+  color: #fff;
+  padding: 0.5rem 0.8rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
 /* Buttons */
 .group-btn {
   padding: 0.5rem 1rem;


### PR DESCRIPTION
## Summary
- add slide-out side nav for selecting groups
- switch index page to load the advanced script
- style the new navigation controls

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841e0c870048323ac6fc3c37f247852