### PR TITLE
Show all items by default

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3,7 +3,7 @@ let filesToUpload = [], currentGroup = 'root';
 
 // Removed loadGroups()
 
-async function loadGallery(group = 'root') {
+async function loadGallery(group = '') {
   const res = await fetch(`${API_BASE}/api/gallery?group=${encodeURIComponent(group)}`);
   const items = await res.json();
   const container = document.getElementById('gallery');
@@ -61,7 +61,7 @@ document.getElementById('uploadBtn').onclick = async () => {
   btn.disabled = false;
   btn.textContent = 'Upload';
   document.getElementById('closeModal').click();
-  loadGallery(currentGroup);
+  loadGallery('');
   showToast('Upload complete!');
 };
 

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -2,7 +2,7 @@
 const API_BASE = 'https://jimi421-art.jimi421.workers.dev';
 
 let allItems = [];       // holds { key, url, title, tags, favorite, metaExists }
-let currentGroup = 'no-meta';
+let currentGroup = 'all';
 let currentSubGroup = 'all';
 
 async function loadGroups() {
@@ -32,7 +32,8 @@ async function loadGroups() {
   noBtn.onclick = () => selectGroup('no-meta', noBtn);
   container.appendChild(noBtn);
 
-  selectGroup(currentGroup, noBtn);
+  const defaultBtn = currentGroup === 'no-meta' ? noBtn : allBtn;
+  selectGroup(currentGroup, defaultBtn);
 }
 
 function selectGroup(group, btn) {


### PR DESCRIPTION
## Summary
- default galleries to show all items
- keep groups available but default to `all`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841e2c6b018832394b74fa852241d95